### PR TITLE
Fixed sending the requests with multiple parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.dajlab</groupId>
 	<artifactId>bricklinkapi</artifactId>
-	<version>0.0.3</version>
+	<version>0.0.4</version>
 	<packaging>jar</packaging>
 
 	<name>BrickLink API</name>
@@ -78,20 +78,20 @@
 				</executions>
 			</plugin>
 
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-gpg-plugin</artifactId>
-				<version>1.6</version>
-				<executions>
-					<execution>
-						<id>sign-artifacts</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>sign</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
+<!--			<plugin>-->
+<!--				<groupId>org.apache.maven.plugins</groupId>-->
+<!--				<artifactId>maven-gpg-plugin</artifactId>-->
+<!--				<version>1.6</version>-->
+<!--				<executions>-->
+<!--					<execution>-->
+<!--						<id>sign-artifacts</id>-->
+<!--						<phase>verify</phase>-->
+<!--						<goals>-->
+<!--							<goal>sign</goal>-->
+<!--						</goals>-->
+<!--					</execution>-->
+<!--				</executions>-->
+<!--			</plugin>-->
 			
 		</plugins>
 	</build>

--- a/src/main/java/org/dajlab/bricklinkapi/v1/service/impl/AbstractBricklinkService.java
+++ b/src/main/java/org/dajlab/bricklinkapi/v1/service/impl/AbstractBricklinkService.java
@@ -121,9 +121,9 @@ public abstract class AbstractBricklinkService {
 		if (parameters != null) {
 			StringBuilder params = new StringBuilder();
 			for (Entry<String, String> param : parameters.entrySet()) {
-				params.append(param.getKey() + "=" + param.getValue());
+				params.append("&" + param.getKey() + "=" + param.getValue());
 			}
-			baseUrl = baseUrl + "?" + params;
+			baseUrl = baseUrl + "?" + params.substring(1);
 		}
 
 		String encodedUrl = buildUrl(method, baseUrl, parameters);

--- a/src/main/java/org/dajlab/bricklinkapi/v1/service/impl/BLAuthSigner.java
+++ b/src/main/java/org/dajlab/bricklinkapi/v1/service/impl/BLAuthSigner.java
@@ -3,11 +3,11 @@ package org.dajlab.bricklinkapi.v1.service.impl;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
+import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
@@ -63,8 +63,8 @@ public class BLAuthSigner {
 	public BLAuthSigner(String consumerKey, String consumerSecret) {
 		this.consumerKey = consumerKey;
 		this.consumerSecret = consumerSecret;
-		this.oauthParameters = new HashMap<>();
-		this.queryParameters = new HashMap<>();
+		this.oauthParameters = new TreeMap<>();
+		this.queryParameters = new TreeMap<>();
 		this.timer = new Timer();
 	}
 
@@ -88,7 +88,7 @@ public class BLAuthSigner {
 	public Map<String, String> getFinalOAuthParams() throws BricklinkException {
 		String signature = computeSignature();
 
-		Map<String, String> params = new HashMap<>();
+		Map<String, String> params = new TreeMap<>();
 		params.putAll(oauthParameters);
 		params.put(SIGNATURE, signature);
 
@@ -181,7 +181,7 @@ public class BLAuthSigner {
 		private static final Map<String, String> ENCODING_RULES;
 
 		static {
-			Map<String, String> rules = new HashMap<>();
+			Map<String, String> rules = new TreeMap<>();
 			rules.put("*", "%2A");
 			rules.put("+", "%20");
 			rules.put("%7E", "~");

--- a/src/main/java/org/dajlab/bricklinkapi/v1/service/impl/CatalogItemServiceImpl.java
+++ b/src/main/java/org/dajlab/bricklinkapi/v1/service/impl/CatalogItemServiceImpl.java
@@ -15,8 +15,8 @@
  */
 package org.dajlab.bricklinkapi.v1.service.impl;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 import org.dajlab.bricklinkapi.v1.enumeration.Method;
 import org.dajlab.bricklinkapi.v1.enumeration.Type;
@@ -117,7 +117,7 @@ public class CatalogItemServiceImpl extends AbstractBricklinkService implements 
 
 		Map<String, String> parameters = null;
 		if (colorId != null) {
-			parameters = new HashMap<>();
+			parameters = new TreeMap<>();
 			parameters.put("color_id", colorId.toString());
 		}
 		String uri = BASE_URI + type.name() + "/" + no + "/supersets";
@@ -153,7 +153,7 @@ public class CatalogItemServiceImpl extends AbstractBricklinkService implements 
 		String uri = BASE_URI + type.name() + "/" + no + "/subsets";
 		Map<String, String> mapParameters = null;
 		if (parameters != null) {
-			mapParameters = new HashMap<>();
+			mapParameters = new TreeMap<>();
 			if (parameters.getColorId() != null) {
 				mapParameters.put("color_id", parameters.getColorId().toString());
 			}
@@ -210,7 +210,7 @@ public class CatalogItemServiceImpl extends AbstractBricklinkService implements 
 		String uri = BASE_URI + type.name() + "/" + no + "/price";
 		Map<String, String> mapParameters = null;
 		if (parameters != null) {
-			mapParameters = new HashMap<>();
+			mapParameters = new TreeMap<>();
 			if (parameters.getColorId() != null) {
 				mapParameters.put("color_id", parameters.getColorId().toString());
 			}

--- a/src/main/java/org/dajlab/bricklinkapi/v1/service/impl/ItemMappingServiceImpl.java
+++ b/src/main/java/org/dajlab/bricklinkapi/v1/service/impl/ItemMappingServiceImpl.java
@@ -15,8 +15,8 @@
  */
 package org.dajlab.bricklinkapi.v1.service.impl;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 import org.dajlab.bricklinkapi.v1.enumeration.Method;
 import org.dajlab.bricklinkapi.v1.enumeration.Type;
@@ -73,7 +73,7 @@ public class ItemMappingServiceImpl extends AbstractBricklinkService implements 
 
 		Map<String, String> parameters = null;
 		if (colorId != null) {
-			parameters = new HashMap<>();
+			parameters = new TreeMap<>();
 			parameters.put("color_id", colorId.toString());
 		}
 		String uri = BASE_URI + Type.PART.name() + "/" + no;

--- a/src/test/java/org/dajlab/bricklinkapi/v1/service/CatalogItemServiceTest.java
+++ b/src/test/java/org/dajlab/bricklinkapi/v1/service/CatalogItemServiceTest.java
@@ -4,9 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.ResourceBundle;
+import java.util.TreeMap;
 
 import org.dajlab.bricklinkapi.v1.enumeration.Type;
 import org.dajlab.bricklinkapi.v1.service.impl.CatalogItemServiceImpl;
@@ -122,7 +122,7 @@ public class CatalogItemServiceTest {
 
 			PriceGuide price = null;
 
-			Map<String, Integer> parts = new HashMap<>();
+			Map<String, Integer> parts = new TreeMap<>();
 			parts.put("3003", 9);
 			parts.put("3003", 1);
 			parts.put("10884", 110);


### PR DESCRIPTION
With the current version there was no way how to combine request parameters because the parameters were joined the wrong way (missing `&` sign). Typical use case was to query price guide by color and used/new parameter. Using `TreeMap` guarantees that the parameters will be sorted alphabetically.